### PR TITLE
Fix for importing from node_modules as library.

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -31,7 +31,7 @@ var lessToJs = exports.lessToJs = function lessToJs(lessFile) {
         sortedLessVars[sortedKey] = lessVars[sortedKey];
     });
 
-    return 'export default ' + (0, _jsObjectPrettyPrint.pretty)(sortedLessVars);
+    return 'module.exports = ' + (0, _jsObjectPrettyPrint.pretty)(sortedLessVars);
 };
 
 var generateJsFile = exports.generateJsFile = function generateJsFile(lessFile, destFile) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,7 +19,7 @@ export const lessToJs = (lessFile) => {
         sortedLessVars[sortedKey] = lessVars[sortedKey];
     });
 
-    return `export default ${pretty(sortedLessVars)}`;
+    return `module.exports = ${pretty(sortedLessVars)}`;
 };
 
 export const generateJsFile = (lessFile, destFile) => new Promise((resolve, reject) => {

--- a/tests/unit/main-spec.js
+++ b/tests/unit/main-spec.js
@@ -6,7 +6,7 @@ describe('javascript generation', () => {
             expect(lessToJs(`
                 @height: 60%;
                 @width: 600px;
-            `)).toEqual(`export default {
+            `)).toEqual(`module.exports = {
     height: \"60%\",
     width: \"600px\"
 }
@@ -17,7 +17,7 @@ describe('javascript generation', () => {
             expect(lessToJs(`
                 @content-component-width: 600px;
                 @content-main-width: 60%;
-            `)).toEqual(`export default {
+            `)).toEqual(`module.exports = {
     \"content-component-width\": \"600px\",
     "content-main-width": \"60%\"
 }
@@ -29,7 +29,7 @@ describe('javascript generation', () => {
                 height: 30px; 
                 @content-component-width: 600px;
                 @content-main-width: 60%;
-            `)).toEqual(`export default {
+            `)).toEqual(`module.exports = {
     \"content-component-width\": \"600px\",
     "content-main-width": \"60%\"
 }
@@ -40,7 +40,7 @@ describe('javascript generation', () => {
                 expect(lessToJs(`
                 @width: 600px;
                 @height: 60%;
-            `)).toEqual(`export default {
+            `)).toEqual(`module.exports = {
     height: \"60%\",
     width: \"600px\"
 }


### PR DESCRIPTION
Right now, when I try to `import colors from 'blah/blah/variables.js';` I get an error running jest tests in the main code base which is only importing from a file generated by this library, because webpack is not handling the loading of modules when jest tests run.

So `export default`, which is ES6 syntax would not work.

Making this PR with `module.exports =` instead.